### PR TITLE
Read and maintain column attributes

### DIFF
--- a/R/read_csvy.R
+++ b/R/read_csvy.R
@@ -168,12 +168,15 @@ add_variable_metadata <- function(data, fields, try_to_factorize = "never") {
         
         # add 'title' field
         if ("title" %in% names(fields_this_col)) {
-            attr(data[[i]], "label") <- fields_this_col[["label"]]
+            attr(data[[i]], "label") <- fields_this_col[["title"]]
         }
         # add 'description' field
         if ("description" %in% names(fields_this_col)) {
             attr(data[[i]], "description") <- fields_this_col[["description"]]
         }
+        ## store attributes already calculated
+        dat_attributes <- attributes(data[[i]])
+        
         # handle 'type' and 'format' fields
         ## 'type'
         if ("type" %in% names(fields_this_col)) {
@@ -206,6 +209,8 @@ add_variable_metadata <- function(data, fields, try_to_factorize = "never") {
             } else if (fields_this_col[["type"]] == "number") {
                 try(data[[i]] <- as.numeric(data[[i]]))
             }
+            ## replace attributes
+            attributes(data[[i]]) <- dat_attributes
         }
         ## 'format' (just added as an attribute for now)
         if ("format" %in% names(fields_this_col)) {

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+jcarroll.com.au

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-csvy.jcarroll.com.au

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-jcarroll.com.au
+csvy.jcarroll.com.au


### PR DESCRIPTION
In reference to #20:

* The `label` column was attempted to be read, but it doesn't exist
* The attributes were stripped on type conversion

This resolves the current check failure (12 pass, 0 fail) and restores check to 0 | 0 | 0 status.